### PR TITLE
Remove dependency to sassc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem 'haml', '< 6.0'    # Haml 6 would require udpating our filter registration c
 # Enable a Markdown gem (only rdiscount seems to work w/ the site):
 gem 'rdiscount', '~> 2.0.7', :platforms => [:ruby]
 
-# using libsass to fasten Sass compilation
-gem 'sassc'
 gem 'sass'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,8 +102,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     shellany (0.0.1)
     temple (0.10.3)
     thor (1.3.0)
@@ -126,7 +124,6 @@ DEPENDENCIES
   rake
   rdiscount (~> 2.0.7)
   sass
-  sassc
   uglifier
   webrick
 

--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -1,6 +1,5 @@
 require 'mytagger'
 require 'relative'
-require 'sassc'
 require 'link_renderer'
 require 'redirect_creator'
 


### PR DESCRIPTION
From what I can see its only purpose is to make sass compilation faster, and it visibly introduces problems ("nil" exceptions). The build is fast enough as it is, so let's get rid of this.