### PR TITLE
Remove unnecessary dependency to rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'haml', '< 6.0'    # Haml 6 would require udpating our filter registration c
 gem 'rdiscount', '~> 2.0.7', :platforms => [:ruby]
 
 gem 'sass'
-gem 'rake'
 
 # For previews
 gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
       method_source (~> 1.0)
     public_suffix (6.0.1)
     rack (2.2.9)
-    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -121,7 +120,6 @@ DEPENDENCIES
   haml (< 6.0)
   htmlcompressor
   json
-  rake
   rdiscount (~> 2.0.7)
   sass
   uglifier


### PR DESCRIPTION
Rake comes pre-installed on the builder image, and is used to start/build the app.
We don't need it as a *dependency*.